### PR TITLE
fartbot streamline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-authtoken.py
+config.py
 __pycache__/

--- a/example_config.py
+++ b/example_config.py
@@ -1,0 +1,8 @@
+# Actual config file has auth token in it (scary!) so it is in .gitignore
+# Here is what the config.py should look like
+token = ''    # auth token
+guild = 0     # guild id
+channel = 0   # channel id where you can only say 'fart club'
+poo_clan = 0  # role id of poo clan
+general = 0   # role id to let people talk in general
+dbpath = ''   # /path/to/your/sqlite/database.db

--- a/example_config.py
+++ b/example_config.py
@@ -1,8 +1,0 @@
-# Actual config file has auth token in it (scary!) so it is in .gitignore
-# Here is what the config.py should look like
-token = ''    # auth token
-guild = 0     # guild id
-channel = 0   # channel id where you can only say 'fart club'
-poo_clan = 0  # role id of poo clan
-general = 0   # role id to let people talk in general
-dbpath = ''   # /path/to/your/sqlite/database.db

--- a/example_config.txt
+++ b/example_config.txt
@@ -1,0 +1,8 @@
+Actual config file has auth token in it (scary!) so it is in .gitignore
+Here is what the config.py should look like
+guild = 0     guild id
+channel = 0   channel id where you can only say 'fart club'
+poo_clan = 0  role id of poo clan
+general = 0   role id to let people talk in general
+dbpath = ''   /path/to/your/sqlite/database.db
+token = ''    auth token

--- a/fartbot.py
+++ b/fartbot.py
@@ -239,7 +239,7 @@ async def shutdown(interaction):
 @aiocron.crontab('*/20 * * * *')
 async def rm_roles():
     guild = bot.get_guild(config.guild)
-    role = get(guild.roles, id=config.role) 
+    role = get(guild.roles, id=config.general) 
     for member in guild.members:
         await member.remove_roles(role)
 

--- a/main.py
+++ b/main.py
@@ -1,11 +1,12 @@
 from flask import Flask, render_template
 import sqlite3
+from config import dbpath
 
 app = Flask(__name__)
 
 @app.route("/")
 def main():
-    cur = sqlite3.connect("/home/pi/projects/fartbot/fartstreak.db").cursor()
+    cur = sqlite3.connect(dbpath).cursor()
     res = cur.execute('SELECT * FROM fartstreak').fetchall()
     rend = sorted(res, key=lambda x: x[5])
     out = rend[::-1]

--- a/reset_current_streaks.py
+++ b/reset_current_streaks.py
@@ -1,8 +1,9 @@
 import sqlite3
 from datetime import date
 from datetime import timedelta
+from config import dbpath
 
-connection = sqlite3.connect("/home/pi/projects/fartbot/fartstreak.db")
+connection = sqlite3.connect(dbpath)
 cur = connection.cursor()
 rows = cur.execute('SELECT * FROM fartstreak').fetchall()
 


### PR DESCRIPTION
The changes made in this pr do not alter the core functionality of fartbot (hopefully) but they do improve the code in a few ways:
- fartbot.py now uses discord.ext.commands instead of discord.app_commands, which combines `tree` and `client` into one `bot` object.
- sensitive slash commands are restricted to the owner of the bot
- all hard-coded ids are now imported from a config.py file

DISCLAIMER: this code is untested and likely will have a bug or two. Pull at your own risk